### PR TITLE
Add document type to cover / footer

### DIFF
--- a/raw/mock_exam/build.gradle
+++ b/raw/mock_exam/build.gradle
@@ -31,12 +31,7 @@ ext {
 
 class RenderMockExamTask extends AsciidoctorTask {
     @Inject
-    RenderMockExamTask(String fileName, String versionDate, String language, boolean withAnswers) {
-
-        def docType = ' (Q)'
-        if (withAnswers) {
-            docType = ' (A)'
-        }
+    RenderMockExamTask(String fileName, String versionDate, String language, boolean withAnswers, String docType) {
 
         sourceDir = new File("./docs/")
         sources {
@@ -51,9 +46,9 @@ class RenderMockExamTask extends AsciidoctorTask {
         attributes = [
                 'icons'           : 'font',
                 'version-label'   : '',
-                'revnumber'       : fileVersion,
-                'revdate'         : versionDate + docType,
-                'document-version': fileVersion + "-" + versionDate + docType,
+                'revnumber'       : docType + ' ' + fileVersion,
+                'revdate'         : versionDate,
+                'document-version': docType + ' ' + fileVersion + "-" + versionDate,
                 'currentDate'     : versionDate,
                 'language'        : language,
                 'withAnswers'     : withAnswers,
@@ -71,14 +66,14 @@ task buildDocs {
 }
 
 task renderQuestionsOnlyDE(type: RenderMockExamTask,
-        constructorArgs: [fileName, versionDate, "DE", false]) {
+        constructorArgs: [fileName, versionDate, "DE", false, "Fragebogen"]) {
     doLast {
         addSuffixToMockExam("-questions-de")
     }
 }
 
 task renderQuestionsAndAnswersDE(type: RenderMockExamTask,
-        constructorArgs: [fileName, versionDate, "DE", true]) {
+        constructorArgs: [fileName, versionDate, "DE", true, "Antwortbogen"]) {
     doLast {
         addSuffixToMockExam("-answers-de")
     }
@@ -86,14 +81,14 @@ task renderQuestionsAndAnswersDE(type: RenderMockExamTask,
 
 
 task renderQuestionsOnlyEN(type: RenderMockExamTask,
-        constructorArgs: [fileName, versionDate, "EN", false]) {
+        constructorArgs: [fileName, versionDate, "EN", false, "Question Sheet"]) {
     doLast {
         addSuffixToMockExam("-questions-en")
     }
 }
 
 task renderQuestionsAndAnswersEN(type: RenderMockExamTask,
-        constructorArgs: [fileName, versionDate, "EN", true]) {
+        constructorArgs: [fileName, versionDate, "EN", true, "Answer Sheet"]) {
     doLast {
         addSuffixToMockExam("-answers-en")
     }

--- a/raw/mock_exam/build.gradle
+++ b/raw/mock_exam/build.gradle
@@ -32,6 +32,12 @@ ext {
 class RenderMockExamTask extends AsciidoctorTask {
     @Inject
     RenderMockExamTask(String fileName, String versionDate, String language, boolean withAnswers) {
+
+        def docType = ' (Q)'
+        if (withAnswers) {
+            docType = ' (A)'
+        }
+
         sourceDir = new File("./docs/")
         sources {
             include "${fileName}.adoc"
@@ -46,8 +52,8 @@ class RenderMockExamTask extends AsciidoctorTask {
                 'icons'           : 'font',
                 'version-label'   : '',
                 'revnumber'       : fileVersion,
-                'revdate'         : versionDate,
-                'document-version': fileVersion + "-" + versionDate,
+                'revdate'         : versionDate + docType,
+                'document-version': fileVersion + "-" + versionDate + docType,
                 'currentDate'     : versionDate,
                 'language'        : language,
                 'withAnswers'     : withAnswers,


### PR DESCRIPTION
We use (Q) or (A) to denote the type of the document,
either Question Sheet (Q) or Answer Sheet (A)

Close #62 