### PR TITLE
Fix score description in English questions

### DIFF
--- a/raw/mock_exam/docs/questions/question-05.adoc
+++ b/raw/mock_exam/docs/questions/question-05.adoc
@@ -54,7 +54,7 @@ Welche VIER der folgenden Techniken sind am besten zur Darstellung von Abläufen
 |===
 | P-Question: 
 | Select the **four** best fitting answers
-| 1 Punkt
+| 1 point
 |===
 
 Which FOUR of the following techniques are best suited to illustrate the workflow or behavior of the system at runtime?

--- a/raw/mock_exam/docs/questions/question-06.adoc
+++ b/raw/mock_exam/docs/questions/question-06.adoc
@@ -45,7 +45,7 @@ Welche DREI der folgenden Grundsätze gelten für das Testen?
 |===
 | P-Question: 
 | Select the **three** best fitting answers
-| 1 Punkt
+| 1 point
 |===
 
 Which THREE of the following principles apply to testing?

--- a/raw/mock_exam/docs/questions/question-22.adoc
+++ b/raw/mock_exam/docs/questions/question-22.adoc
@@ -43,7 +43,7 @@ Welche der folgenden Eigenschaften lässt sich am ehesten durch eine Schichtenar
 |===
 | A-Question:
 | Select one option
-| 1 Point
+| 1 point
 |===
 
 

--- a/raw/mock_exam/docs/questions/question-23.adoc
+++ b/raw/mock_exam/docs/questions/question-23.adoc
@@ -43,7 +43,7 @@ Für welche Art von System kann das Blackboard-Architekturmuster verwendet werde
 |===
 | A-Question:
 | Select one option
-| 1 Point
+| 1 point
 |===
 
 

--- a/raw/mock_exam/docs/questions/question-24.adoc
+++ b/raw/mock_exam/docs/questions/question-24.adoc
@@ -40,7 +40,7 @@ Welche Ziele versuchen Sie mit dem Dependency-Inversion-Prinzip zu erreichen?
 |===
 | A-Question:
 | Select one option
-| 1 Point
+| 1 point
 |===
 
 

--- a/raw/mock_exam/docs/questions/template-A-question.adoc
+++ b/raw/mock_exam/docs/questions/template-A-question.adoc
@@ -40,7 +40,7 @@
 |===
 | A-Question:
 | Select one option
-| 1 Point
+| 1 point
 |===
 
 


### PR DESCRIPTION
- align capitalization of "point"
- fix missing translation of "Punkt"

Additionally, question 9 and 13 have a mismatch between the number of points in German and English.
-> Let's discuss in #92 
