### PR TITLE
Align scoring between German and English

### DIFF
--- a/raw/mock_exam/docs/questions/question-09.adoc
+++ b/raw/mock_exam/docs/questions/question-09.adoc
@@ -6,7 +6,7 @@
 |===
 |K-Frage: 
 |Wählen Sie für jede Zeile „Richtig“ oder „Falsch“ aus. 
-| 2 Punkte
+| 1 Punkt
 |===
 
 Stellen Sie sich vor, Sie sind Softwarearchitekt:in für eine große und verteilte Geschäftsanwendung im Banken- oder Versicherungsbereich. 
@@ -47,7 +47,7 @@ Welche der folgenden Aussagen sind für diese Situation richtig und welche falsc
 |===
 |K-Question: 
 |Select „True" or „False" for every line. 
-| 2 points
+| 1 point
 |===
 
 Put yourself in the position of a software architect for a large, distributed business application in the banking or insurance domain. 

--- a/raw/mock_exam/docs/questions/question-09.adoc
+++ b/raw/mock_exam/docs/questions/question-09.adoc
@@ -47,7 +47,7 @@ Welche der folgenden Aussagen sind für diese Situation richtig und welche falsc
 |===
 |K-Question: 
 |Select „True" or „False" for every line. 
-| 1 point
+| 2 points
 |===
 
 Put yourself in the position of a software architect for a large, distributed business application in the banking or insurance domain. 

--- a/raw/mock_exam/docs/questions/question-13.adoc
+++ b/raw/mock_exam/docs/questions/question-13.adoc
@@ -51,7 +51,7 @@ Geben Sie für jede der folgenden Aussagen an, ob sie richtig oder falsch ist.
 |===
 |K-Question: 
 |Select „true“ or „false" for every line.
-| 2 points
+| 1 point
 |===
 
 Decide for each of the following statements whether it is true or false.


### PR DESCRIPTION
For question 9 and 13, there's a mismatch between the number of points assigned in the German and the English version.
Assuming the German version is the ' correct' one -> adjusting in the English translation.

If it's supposed to be the other way around just let me know and I'll switch it:)