### PR TITLE
Use standard English quotation marks in English-language questions

### DIFF
--- a/raw/mock_exam/docs/questions/question-04.adoc
+++ b/raw/mock_exam/docs/questions/question-04.adoc
@@ -48,7 +48,7 @@ Bei Ihrem Projekt arbeiten drei Architekt:innen und sieben Entwickler:innen an d
 [cols="2,8,2", frame=ends, grid=rows]
 |===
 |K-Question:
-|Select "appropriate“ or „not appropriate" for every line.
+|Select “appropriate” or “not appropriate” for every line.
 | 2 points
 |===
 

--- a/raw/mock_exam/docs/questions/question-07.adoc
+++ b/raw/mock_exam/docs/questions/question-07.adoc
@@ -50,7 +50,7 @@ Welche der folgenden Aussagen zum Entwurfsprinzip "Information Hiding" sind rich
 [cols="2,8,2", frame=ends, grid=rows]
 |===
 |K-Question: 
-|Select "true" or „false" for every line. 
+|Select “true” or “false” for every line. 
 | 1 point
 |===
 

--- a/raw/mock_exam/docs/questions/question-09.adoc
+++ b/raw/mock_exam/docs/questions/question-09.adoc
@@ -46,7 +46,7 @@ Welche der folgenden Aussagen sind für diese Situation richtig und welche falsc
 [cols="2,8,2", frame=ends, grid=rows]
 |===
 |K-Question: 
-|Select „true" or „false" for every line. 
+|Select “true” or “false” for every line. 
 | 1 point
 |===
 

--- a/raw/mock_exam/docs/questions/question-12.adoc
+++ b/raw/mock_exam/docs/questions/question-12.adoc
@@ -55,7 +55,7 @@ Welche der folgenden Aussagen zu Architekturentscheidungen sind wahr, welche fal
 [cols="2,8,2", frame=ends, grid=rows]
 |===
 |K-Question: 
-|Select „true“ or „false" for every option.
+|Select “true” or “false” for every option.
 | 1 point
 |===
 

--- a/raw/mock_exam/docs/questions/question-13.adoc
+++ b/raw/mock_exam/docs/questions/question-13.adoc
@@ -50,7 +50,7 @@ Geben Sie für jede der folgenden Aussagen an, ob sie richtig oder falsch ist.
 [cols="2,8,2", frame=ends, grid=rows]
 |===
 |K-Question: 
-|Select „true“ or „false" for every line.
+|Select “true” or “false” for every line.
 | 1 point
 |===
 

--- a/raw/mock_exam/docs/questions/question-14.adoc
+++ b/raw/mock_exam/docs/questions/question-14.adoc
@@ -50,7 +50,7 @@ Geben Sie an, welche der folgenden Aussagen zu Projektzielen und Architekturziel
 [cols="2,8,2", frame=ends, grid=rows]
 |===
 |K-Question: 
-|Select „true“ or „false" for every line.
+|Select “true” or “false” for every line.
 | 2 points
 |===
 

--- a/raw/mock_exam/docs/questions/question-15.adoc
+++ b/raw/mock_exam/docs/questions/question-15.adoc
@@ -49,7 +49,7 @@ Was bedeutet die Regel „explizit, nicht implizit“ für die Architekturarbeit
 | 1 point
 |===
 
-What does the rule „explicit, not implicit“ mean for architecture work?
+What does the rule “explicit, not implicit” mean for architecture work?
 Choose the TWO best-fitting answers.
 
 [cols="1a,1,10", frame=none, grid=none]

--- a/raw/mock_exam/docs/questions/question-25.adoc
+++ b/raw/mock_exam/docs/questions/question-25.adoc
@@ -50,7 +50,7 @@ Was sind die Eigenschaften von enger (hoher) bzw. loser (niedriger) Kopplung?
 [cols="2,8,2", frame=ends, grid=rows]
 |===
 |K-Question: 
-|Select „tight coupling“ or „loose coupling" for each line.
+|Select “tight coupling” or “loose coupling” for each line.
 | 1 point
 |===
 

--- a/raw/mock_exam/docs/questions/question-26.adoc
+++ b/raw/mock_exam/docs/questions/question-26.adoc
@@ -49,7 +49,7 @@ Anders gesagt: Was könnte passieren, wenn Teile des Quellcodes oder der Konfigu
 | 2 points
 |===
 
-Which two statements about the principle „Don’t repeat yourself” (DRY) fit best?
+Which two statements about the principle “Don’t repeat yourself” (DRY) fit best?
 In other words: What could happen, if parts of the source code or configuration do exist in multiple copies in the system?
 
 [cols="1a,1,10", frame=none, grid=none]

--- a/raw/mock_exam/docs/questions/question-27.adoc
+++ b/raw/mock_exam/docs/questions/question-27.adoc
@@ -52,7 +52,7 @@ Geben Sie für jede der folgenden Aussagen an, ob sie richtig oder falsch ist.
 [cols="2,8,2", frame=ends, grid=rows]
 |===
 |K-Question: 
-|Select „true“ or „false" for every line.
+|Select “true” or “false” for every line.
 | 2 points
 |===
 

--- a/raw/mock_exam/docs/questions/question-28.adoc
+++ b/raw/mock_exam/docs/questions/question-28.adoc
@@ -51,7 +51,7 @@ a| Solange die Notation (z.{nbsp}B. mithilfe einer Legende) erläutert wird, kan
 [cols="2,8,2", frame=ends, grid=rows]
 |===
 |K-Question: 
-|Select „true“ or „false" for every line.
+|Select “true” or “false” for every line.
 | 2 points
 |===
 

--- a/raw/mock_exam/docs/questions/question-32.adoc
+++ b/raw/mock_exam/docs/questions/question-32.adoc
@@ -57,7 +57,7 @@ Kreuzen Sie an, welche der folgenden Aussagen richtig und welche falsch sind.
 [cols="2,8,2", frame=ends, grid=rows]
 |===
 |K-Question: 
-|Select „true“ or „false" for every line.
+|Select “true” or “false” for every line.
 | 2 points
 |===
 

--- a/raw/mock_exam/docs/questions/question-33.adoc
+++ b/raw/mock_exam/docs/questions/question-33.adoc
@@ -52,11 +52,11 @@ Kreuzen Sie an, welche der folgenden Aussagen zu Architektur- /Designentscheidun
 [cols="2,8,2", frame=ends, grid=rows]
 |===
 |K-Question: 
-|Select „true“ or „false" for every line.
+|Select “true” or “false” for every line.
 | 1 point
 |===
 
-One definition says: “Software architecture is the sum of all the decisions you have taken during development.
+One definition says: “Software architecture is the sum of all the decisions you have taken during development.”
 Check which of the following statements about architectural/design decision is true and which is false.
 
 

--- a/raw/mock_exam/docs/questions/question-34.adoc
+++ b/raw/mock_exam/docs/questions/question-34.adoc
@@ -61,7 +61,7 @@ Welche der folgenden Aussagen sind typische Gründe zur Führung einer (angemess
 [cols="2,8,2", frame=ends, grid=rows]
 |===
 |K-Question: 
-|Select „typical“ or „not typical" for every line.
+|Select “typical” or “not typical” for every line.
 | 2 points
 |===
 

--- a/raw/mock_exam/docs/questions/question-35.adoc
+++ b/raw/mock_exam/docs/questions/question-35.adoc
@@ -52,7 +52,7 @@ Welche der folgenden Eigenschaftspaare stehen üblicherweise miteinander in Konf
 [cols="2,8,2", frame=ends, grid=rows]
 |===
 |K-Question: 
-|Select „conflicting“ or „not conflicting" for every line.
+|Select “conflicting” or “not conflicting” for every line.
 | 1 point
 |===
 

--- a/raw/mock_exam/docs/questions/template-K-question.adoc
+++ b/raw/mock_exam/docs/questions/template-K-question.adoc
@@ -45,7 +45,7 @@
 [cols="2,8,2", frame=ends, grid=rows]
 |===
 |K-Question: 
-|Select „appropriate“ or „not appropriate" for every line.
+|Select “appropriate” or “not appropriate” for every line.
 | 2 points
 |===
 


### PR DESCRIPTION
I went for the *typographic* (curly) quotation marks instead of the neutral (non curly) ones.

> “ ”
vs.
> " "

However, and this might actually be the easier maintainable way to go, some of the German-language questions use the standard neutral quotation marks (which are actually available on normal keyboards 😅). Maybe it would be better to just use those everywhere (and in all languages?)

Additionally, there was a closing quotation mark missing in question 33 -> added