### PR TITLE
Fix duplicated sentence in answer options of Q-17-13-01

### DIFF
--- a/raw/mock_exam/docs/questions/question-03.adoc
+++ b/raw/mock_exam/docs/questions/question-03.adoc
@@ -77,7 +77,7 @@ Which FOUR of the following statements about (crosscutting) concepts are most ap
 
 | {n}
 | (d)
-| For each quality goal there should be an explicitly documented concept. Concepts are a means to increase consistency.
+| For each quality goal there should be an explicitly documented concept.
 
 
 | {y}


### PR DESCRIPTION
In Q-17-13-01 (raw/mock_exam/docs/questions/question-03.adoc), a sentence in the English answers is duplicated from answer option **e** to answer option **d**: "Concepts are a means to increase consistency."

In the German answer of this question, the duplication isn't there. Looks like the result of copy/paste or formatting issue.
This PR removes the duplicate sentence from the English answers.